### PR TITLE
Expose actual light ids to configure interface

### DIFF
--- a/interfaces/philipsHue/config.html
+++ b/interfaces/philipsHue/config.html
@@ -294,12 +294,12 @@
                 const status = this.templates.status.content.cloneNode(true);
                 status.querySelector('.connection').innerText = setting.connection;
                 const lights = status.querySelector('.lights');
-                if (setting.lights > 0) {
+                if (setting.lights.length > 0) {
                     lights.innerHTML = '';
                 }
-                for (let i = 0 ; i < setting.lights; i++) {
+                for (let lightId of setting.lights) {
                     const light = this.templates.light.content.cloneNode(true);
-                    light.querySelector('.name').innerText = `Light ${i + 1}`;
+                    light.querySelector('.name').innerText = lightId;
                     lights.appendChild(light);
                 }
                 this.domObjects.appendChild(status);

--- a/interfaces/philipsHue/config.html
+++ b/interfaces/philipsHue/config.html
@@ -225,6 +225,7 @@
 <template id="light">
     <div class="name button green one">Light</div>
     <div style="display:inline-block"></div> <!-- graphic design is my passion -->
+    <div class="humanName button green three">Light</div>
 </template>
 
 <body>
@@ -294,12 +295,14 @@
                 const status = this.templates.status.content.cloneNode(true);
                 status.querySelector('.connection').innerText = setting.connection;
                 const lights = status.querySelector('.lights');
-                if (setting.lights.length > 0) {
+                if (Object.keys(setting.lights).length > 0) {
                     lights.innerHTML = '';
                 }
-                for (let lightId of setting.lights) {
+                for (let lightId in setting.lights) {
+                    const lightInfo = setting.lights[lightId];
                     const light = this.templates.light.content.cloneNode(true);
-                    light.querySelector('.name').innerText = lightId;
+                    light.querySelector('.name').innerText = 'Light' + lightId;
+                    light.querySelector('.humanName').innerText = lightInfo.name;
                     lights.appendChild(light);
                 }
                 this.domObjects.appendChild(status);

--- a/interfaces/philipsHue/index.js
+++ b/interfaces/philipsHue/index.js
@@ -127,7 +127,10 @@ async function getLocalLights(localBridgeIP, username) {
         let light =  new Light(lightId, localBridgeIP, username);
         lights[light.id] = light;
     }
-    return lights;
+    return {
+        lights,
+        lightInfo,
+    };
 }
 
 /**
@@ -371,11 +374,13 @@ if (exports.enabled) {
             });
         }
 
-        lights = await getLocalLights(localBridgeIP, username);
+        const lightResults = await getLocalLights(localBridgeIP, username);
+        lights = lightResults.lights;
+        const lightInfo = lightResults.lightInfo;
 
         console.log('found lights', lights);
         exports.settings.status.connection = 'PAIRED WITH HUE BRIDGE';
-        exports.settings.status.lights = Object.keys(lights);
+        exports.settings.status.lights = lightInfo;
 
         // Set up server-side frames, nodes, and listeners for all known lights
         for (var lightId in lights) {

--- a/interfaces/philipsHue/index.js
+++ b/interfaces/philipsHue/index.js
@@ -375,7 +375,7 @@ if (exports.enabled) {
 
         console.log('found lights', lights);
         exports.settings.status.connection = 'PAIRED WITH HUE BRIDGE';
-        exports.settings.status.lights = Object.keys(lights).length;
+        exports.settings.status.lights = Object.keys(lights);
 
         // Set up server-side frames, nodes, and listeners for all known lights
         for (var lightId in lights) {


### PR DESCRIPTION
If the underlying philips hue API has Light1, Light3, Light17 the configure interface would previously list Light 1, Light 2, Light 3. This change makes it correctly list Light1, Light3, Light17.